### PR TITLE
chore&doc: Add script to update parser msgs and README

### DIFF
--- a/lib/parsing/README.md
+++ b/lib/parsing/README.md
@@ -3,12 +3,13 @@
 We are using [Menhir](http://cambium.inria.fr/~fpottier/menhir/) to generate the parser and [Sedlex](https://github.com/ocaml-community/sedlex) to generate the lexer with Unicode support. Most of the code has comments explaining our decisions (when deemed necessary), but otherwise, the corresponding documentation is the source of truth. 
 
 # Extending/modifying the parser
-Whenever you extend or modify the parser, you need to run the script [update_error_msgs.sh](update_error_msgs.sh) in this folder and update the corresponding error messages in [parserMessages.messages](parserMessages.messages). This is because we are using Menhir's [new way of handling errors](http://cambium.inria.fr/~fpottier/menhir/manual.html#sec68), which makes use of the `.messages` file to print better errors, and this new way follows a different maintentance flow.
+Whenever you extend or modify the parser, you need to run the script [update_error_msgs.sh](update_error_msgs.sh) and update the corresponding error messages in [parserMessages.messages](parserMessages.messages). This is because we are using Menhir's [new way of handling errors](http://cambium.inria.fr/~fpottier/menhir/manual.html#sec68), which makes use of the `.messages` file to print better errors, and this new way follows a different maintentance flow.
 
 After making changes to the parser, run the following command:
 ```bash
-# The script is intended to be run inside the parsing folder
-cd lib/parsing
-. ./update_error_msgs.sh
+# The script is intended to be run at top level
+esy update-parser-errors
+# or alternatively (if dune is available)
+sh lib/parsing/update_error_msgs.sh
 ```
 The script should update the `.messages` file with the new possible erroneous states (or updated ones), for which you need to add a proper error message.

--- a/lib/parsing/README.md
+++ b/lib/parsing/README.md
@@ -1,0 +1,14 @@
+# Overview
+
+We are using [Menhir](http://cambium.inria.fr/~fpottier/menhir/) to generate the parser and [Sedlex](https://github.com/ocaml-community/sedlex) to generate the lexer with Unicode support. Most of the code has comments explaining our decisions (when deemed necessary), but otherwise, the corresponding documentation is the source of truth. 
+
+# Extending/modifying the parser
+Whenever you extend or modify the parser, you need to run the script [update_error_msgs.sh](update_error_msgs.sh) in this folder and update the corresponding error messages in [parserMessages.messages](parserMessages.messages). This is because we are using Menhir's [new way of handling errors](http://cambium.inria.fr/~fpottier/menhir/manual.html#sec68), which makes use of the `.messages` file to print better errors, and this new way follows a different maintentance flow.
+
+After making changes to the parser, run the following command:
+```bash
+# The script is intended to be run inside the parsing folder
+cd lib/parsing
+. ./update_error_msgs.sh
+```
+The script should update the `.messages` file with the new possible erroneous states (or updated ones), for which you need to add a proper error message.

--- a/lib/parsing/update_error_msgs.sh
+++ b/lib/parsing/update_error_msgs.sh
@@ -3,6 +3,9 @@
 # Based off the example Makefile in Menhir's repo
 # https://gitlab.inria.fr/fpottier/menhir/-/blob/master/demos/calc-syntax-errors/Makefile.messages.maintenance
 
+# For simplicity sake, this script is meant to be run inside 
+# the parsing folder. 
+
 dune exec menhir -- parser.mly --list-errors > parserMessages.auto.messages 	
 dune exec menhir -- parser.mly --merge-errors parserMessages.auto.messages --merge-errors parserMessages.messages > parserMessages.merged 	
 mv parserMessages.merged parserMessages.messages

--- a/lib/parsing/update_error_msgs.sh
+++ b/lib/parsing/update_error_msgs.sh
@@ -3,10 +3,12 @@
 # Based off the example Makefile in Menhir's repo
 # https://gitlab.inria.fr/fpottier/menhir/-/blob/master/demos/calc-syntax-errors/Makefile.messages.maintenance
 
-# For simplicity sake, this script is meant to be run inside 
-# the parsing folder. 
+# For simplicity sake, this script is meant to be run at top level
+# For example:
+# esy update-parser-errors
+parsing_lib=lib/parsing
 
-dune exec menhir -- parser.mly --list-errors > parserMessages.auto.messages 	
-dune exec menhir -- parser.mly --merge-errors parserMessages.auto.messages --merge-errors parserMessages.messages > parserMessages.merged 	
-mv parserMessages.merged parserMessages.messages
+dune exec menhir -- $parsing_lib/parser.mly --list-errors > parserMessages.auto.messages 	
+dune exec menhir -- $parsing_lib/parser.mly --merge-errors parserMessages.auto.messages --merge-errors $parsing_lib/parserMessages.messages > parserMessages.merged 	
+mv parserMessages.merged $parsing_lib/parserMessages.messages
 rm -f parserMessages.auto.messages

--- a/lib/parsing/update_error_msgs.sh
+++ b/lib/parsing/update_error_msgs.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Based off the example Makefile in Menhir's repo
+# https://gitlab.inria.fr/fpottier/menhir/-/blob/master/demos/calc-syntax-errors/Makefile.messages.maintenance
+
+dune exec menhir -- parser.mly --list-errors > parserMessages.auto.messages 	
+dune exec menhir -- parser.mly --merge-errors parserMessages.auto.messages --merge-errors parserMessages.messages > parserMessages.merged 	
+mv parserMessages.merged parserMessages.messages
+rm -f parserMessages.auto.messages

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "coverage": "dune runtest --instrument-with=bisect_ppx --force",
     "report": "bisect-ppx-report html",
     "run": "dune exec gcic",
-    "format": "dune build @fmt --auto-promote"
+    "format": "dune build @fmt --auto-promote",
+    "update-parser-errors": "sh lib/parsing/update_error_msgs.sh"
   },
   "dependencies": {
     "ocaml": "4.13.x",

--- a/shell.nix
+++ b/shell.nix
@@ -14,5 +14,6 @@ mkShell {
     alias dune-test="dune runtest"
     alias dune-coverage="dune runtest --instrument-with bisect_ppx --force; bisect-ppx-report html; bisect-ppx-report summary"
     alias dune-run="dune exec gcic"
+    alias update-parser-errors="sh lib/parsing/update_error_msgs.sh"
   '';
 }


### PR DESCRIPTION
Adding the command to be run whenever someone modifies the parser, to update the error messages. 
Added the corresponding links to Menhir's documentation explaining it.